### PR TITLE
Added command to install the dependencies on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ You will need the following dependencies to build DRNSF:
    * GCC >= 6.3.0
    * Visual Studio 2017 _(requires "Desktop development with C++")_
 
+If you are using **Ubuntu** you can install these dependencies with:
+```
+$ sudo apt install libx11-dev pkg-config libepoxy-dev freeglut3-dev libcairo2-dev python3 cmake gcc g++
+```
+
 Depending on your selected frontend and features, you may need more
 dependencies. See `docs/build_options.md` for more details.
 


### PR DESCRIPTION
I simply updated the readme to simplify the way to build and install the drnsf on Ubuntu.
I tested it on Ubuntu 18.04.